### PR TITLE
feat: cache buffers word

### DIFF
--- a/lua/completion_buffers.lua
+++ b/lua/completion_buffers.lua
@@ -1,4 +1,5 @@
 local M = {}
+local api = vim.api
 local completion = require "completion"
 local buffers = require "source.buffers"
 
@@ -9,6 +10,17 @@ function M.add_sources()
   completion.addCompletionSource("buffer", {
     item = buffers.get_buffer_completion_items;
   })
+end
+
+function M.refresh_buffers_word()
+  buffers.caching_buffers_word()
+end
+
+do
+  api.nvim_command("augroup RefreshBufferWords")
+    api.nvim_command("autocmd! *")
+    api.nvim_command("autocmd BufEnter <buffer> lua require'completion_buffers'.refresh_buffers_word()")
+  api.nvim_command("augroup end")
 end
 
 return M


### PR DESCRIPTION
Currently upon every completion we will try to get all the words from every buffers. However this is kind of inefficient since only the current buffers words will be changing. This PR tries to solve this by caching buffers word and only refresh it when `BufEnter`. So we only need to iterate every word when entering the buffer.