### PR TITLE
docs(readme): fix example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ Setup
 The source is automatically registered. You just need to add the source to your completion configuration.
 
 ```
-completion_chain_complete_list = {
-  { complete_items = { 'lsp' } },
-  { complete_items = { 'buffers' } },
-  { mode = { '<c-p>' } },
-  { mode = { '<c-n>' } }
-}
+let g:completion_chain_complete_list = [ 
+  \{ complete_items = ['lsp', 'snippet'] },
+  \{ complete_items = ['buffers'] },
+  \{ mode = '<c-p>' },
+  \{ mode = '<c-n>' }
+\ ]
 ```
 
 ### Configuration


### PR DESCRIPTION
Made the example config a little more copy-paste friendly by:

* copying the default chain completion configuration from [completion-nvim](https://github.com/nvim-lua/completion-nvim/wiki/chain-complete-support)
* adding `'buffers'` to the second completion source